### PR TITLE
Show podIP when describing a pod

### DIFF
--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -51,7 +51,7 @@ If you are running different kubernetes clusters, you may need to specify ```-s 
 
 ### Run an application
 ```sh
-kubectl -s http://localhost:8080 run nginx --image=nginx --port=80
+kubectl -s http://localhost:8080 run-container nginx --image=nginx --port=80
 ```
 
 now run ```docker ps``` you should see nginx running.  You may need to wait a few minutes for the image to get pulled.

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -270,6 +270,7 @@ func describePod(pod *api.Pod, rcs []api.ReplicationController, events *api.Even
 		fmt.Fprintf(out, "Name:\t%s\n", pod.Name)
 		fmt.Fprintf(out, "Image(s):\t%s\n", makeImageList(&pod.Spec))
 		fmt.Fprintf(out, "Node:\t%s\n", pod.Spec.NodeName+"/"+pod.Status.HostIP)
+		fmt.Fprintf(out, "PodIP:\t%s\n", pod.Status.PodIP)
 		fmt.Fprintf(out, "Labels:\t%s\n", formatLabels(pod.Labels))
 		fmt.Fprintf(out, "Status:\t%s\n", string(pod.Status.Phase))
 		fmt.Fprintf(out, "Replication Controllers:\t%s\n", printReplicationControllersByLabels(rcs))


### PR DESCRIPTION
As mentioned in #9462, podIP is useful when checking service binding status, Currently we can not view this information by kubectl commands, display it in describe command.
